### PR TITLE
Remove requirement that ptich and student have a team

### DIFF
--- a/app/models/pitch.rb
+++ b/app/models/pitch.rb
@@ -8,5 +8,5 @@ class Pitch < ApplicationRecord
   belongs_to :student
   belongs_to :cohort, foreign_key: :student_id
   has_many :votes
-  belongs_to :team
+  belongs_to :team, optional: true
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -2,7 +2,7 @@ class Student < ApplicationRecord
   belongs_to :cohort
   has_many :pitches
   has_many :votes
-  belongs_to :team
+  belongs_to :team, optional: true
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/db/migrate/20170513144036_remove_null_from_teams.rb
+++ b/db/migrate/20170513144036_remove_null_from_teams.rb
@@ -1,0 +1,6 @@
+class RemoveNullFromTeams < ActiveRecord::Migration[5.0]
+  def change
+    change_column :teams, :student_id, :integer, :default => nil, :null => true
+    change_column :teams, :pitch_id, :integer, :default => nil, :null => true
+  end
+end


### PR DESCRIPTION
Added optional: true to Teams in Student and Pitch model
Created migration to remove null: true from Team model.